### PR TITLE
Implementation of USB automount service

### DIFF
--- a/recipes-platform/media-automount/files/sbin/mount_device.sh
+++ b/recipes-platform/media-automount/files/sbin/mount_device.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# 
+# This script helps to mount/unmount devices.
+#
+# It is written to be as robust as possible, any failures (for example naming conflicts)
+# abort the operation 
+
+readonly MOUNT_DIR_BASE="/media"
+
+function log()
+{
+    logger -st "mount_device" "$*"
+}
+
+function print_help()
+{
+    echo "Usage: $0 {add|remove} <device_name> (e.g. sdb1)"
+}
+
+if [[ $# -ne 2 ]]; then
+    print_help
+    exit 22
+fi
+
+readonly ACTION=$1
+readonly DEVBASE=$2
+readonly DEVICE="/dev/${DEVBASE}"
+
+log "Processing ${DEVICE}..."
+
+function load_device_properties()
+{
+    # Export device properties by treating the information from (busybox's) blkid as variables
+    eval "$(/sbin/blkid "${DEVICE}" | awk '{for (i=2; i<NF; i++) printf $i " "; print $NF}')"
+
+    if [[ -z "${LABEL}" ]] || [[ -z "${TYPE}" ]]; then
+        log "Error: Could not read device properties for ${DEVICE} via blkid."
+        exit 6
+    fi
+}
+
+function is_mounted()
+{
+    mount | grep "${DEVICE}" &> /dev/null
+}
+
+function get_new_mount_point()
+{
+    echo "${MOUNT_DIR_BASE}/${LABEL}"
+}
+
+function get_existing_mount_point()
+{
+    mount | grep "${DEVICE}" | awk '{ print $3 }'
+}
+
+function get_mount_options()
+{
+    local opts="rw,relatime"
+    if [[ "${TYPE}" == "vfat" ]]; then
+        opts+=",users,gid=100,umask=000,shortname=mixed,utf8=1,flush"
+    fi
+    echo "${opts}"
+}
+
+function do_mount()
+{
+    if is_mounted; then
+        log "Warning: ${DEVICE} is already mounted!"
+        exit 16
+    fi
+    load_device_properties
+
+    local mount_point
+    mount_point="$(get_new_mount_point)"
+    if ! mkdir -p "${mount_point}"; then
+        log "Mount point ${mount_point} already occupied!"
+        exit 17
+    fi
+
+    if ! mount -o "$(get_mount_options)" "${DEVICE}" "${mount_point}"; then
+        log "Error mounting ${DEVICE} (status = $?)"
+        rmdir "${mount_point}"
+        exit 5
+    fi
+    log "**** Mounted ${DEVICE} at ${mount_point}. ****"
+}
+
+function do_unmount()
+{
+    if ! is_mounted; then
+        log "Warning: ${DEVICE} is not mounted (anymore)!"
+    else
+        umount -l "${DEVICE}"
+    fi
+    local mount_point
+    mount_point="$(get_existing_mount_point)"
+    if [[ -e "${mount_point}" ]]; then
+        rmdir "${mount_point}"
+    fi
+    log "**** Unmounted ${DEVICE} and removed ${mount_point}. ****"
+}
+
+case "${ACTION}" in
+    add)
+        do_mount
+        ;;
+    remove)
+        do_unmount
+        ;;
+    *)
+        print_help
+        ;;
+esac

--- a/recipes-platform/media-automount/files/systemd/media-automount@.service
+++ b/recipes-platform/media-automount/files/systemd/media-automount@.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Mount USB drive (/dev/%i)
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/usr/sbin/mount_device add %i
+ExecStop=/usr/sbin/mount_device remove %i

--- a/recipes-platform/media-automount/files/udev/99-local.rules
+++ b/recipes-platform/media-automount/files/udev/99-local.rules
@@ -1,0 +1,2 @@
+KERNEL=="sd[a-z]*",SUBSYSTEM=="block",SUBSYSTEMS=="usb",ACTION=="add",RUN+="systemctl start media-automount@%k.service"
+KERNEL=="sd[a-z]*",SUBSYSTEM=="block",SUBSYSTEMS=="usb",ACTION=="remove",RUN+="systemctl stop media-automount@%k.service"

--- a/recipes-platform/media-automount/media-automount_1.0.bb
+++ b/recipes-platform/media-automount/media-automount_1.0.bb
@@ -1,0 +1,37 @@
+# -------------------
+# Sets up the system to automatically mount media devices
+# -------------------
+
+# Mostly taken from https://serverfault.com/questions/766506/automount-usb-drives-with-systemd/767079.
+
+SUMMARY = "Sets up the system to automatically mount media devices"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI += " \
+    file://sbin/mount_device.sh \
+    file://systemd/media-automount@.service \
+    file://udev/99-local.rules \
+"
+
+RDEPENDS_${PN} += "systemd udev bash"
+
+inherit systemd
+
+FILES_${PN} += " \
+    ${systemd_unitdir}/system/* \
+"
+
+SYSTEMD_AUTO_ENABLE = "enable"
+SYSTEMD_SERVICE_${PN} += "media-automount@.service"
+
+do_install () {
+    install -d ${D}${sbindir}
+    install -d ${D}${systemd_unitdir}/system
+    install -d ${D}${sysconfdir}/udev/rules.d
+
+    install -m 0775 ${WORKDIR}/sbin/mount_device.sh ${D}${sbindir}/mount_device
+    install -m 0644 ${WORKDIR}/systemd/media-automount@.service ${D}${systemd_unitdir}/system/
+    install -m 0644 ${WORKDIR}/udev/99-local.rules ${D}${sysconfdir}/udev/rules.d/
+}


### PR DESCRIPTION
Adds udev rules triggering a systemd service in turn executing a mount script to mount/ unmount USB devices automatically.

This multi-stage process is necessary to avoid conflicts between udev and systemd.