### PR TITLE
[Bugfix] Automount script

### DIFF
--- a/recipes-platform/media-automount/files/sbin/mount-media-device.sh
+++ b/recipes-platform/media-automount/files/sbin/mount-media-device.sh
@@ -51,7 +51,7 @@ function get_new_mount_point()
 
 function get_existing_mount_point()
 {
-    mount | grep "${DEVICE}" | awk '{ print $3 }'
+    mount | grep -m 1 "${DEVICE}" | awk '{ print $3 }'
 }
 
 function get_mount_options()
@@ -90,15 +90,17 @@ function do_unmount()
 {
     if ! is_mounted; then
         log "Warning: ${DEVICE} is not mounted (anymore)!"
-    else
-        umount -l "${DEVICE}"
+        exit 0
     fi
     local mount_point
     mount_point="$(get_existing_mount_point)"
+    
+    umount -l "${DEVICE}"
+    log "**** Unmounted ${DEVICE}. ****"
     if [[ -e "${mount_point}" ]]; then
         rmdir "${mount_point}"
+        log "**** Removed ${mount_point} previously used for ${DEVICE}. ****"
     fi
-    log "**** Unmounted ${DEVICE} and removed ${mount_point}. ****"
 }
 
 case "${ACTION}" in

--- a/recipes-platform/media-automount/files/systemd/media-automount@.service
+++ b/recipes-platform/media-automount/files/systemd/media-automount@.service
@@ -2,7 +2,7 @@
 Description=Mount USB drive (/dev/%i)
 
 [Service]
-Type=oneshot
+Type=simple
 RemainAfterExit=true
-ExecStart=/usr/sbin/mount_device add %i
-ExecStop=/usr/sbin/mount_device remove %i
+ExecStart=/usr/sbin/mount-media-device add %i
+ExecStop=/usr/sbin/mount-media-device remove %i

--- a/recipes-platform/media-automount/files/udev/99-local.rules
+++ b/recipes-platform/media-automount/files/udev/99-local.rules
@@ -1,2 +1,0 @@
-KERNEL=="sd[a-z]*",SUBSYSTEM=="block",SUBSYSTEMS=="usb",ACTION=="add",RUN+="systemctl start media-automount@%k.service"
-KERNEL=="sd[a-z]*",SUBSYSTEM=="block",SUBSYSTEMS=="usb",ACTION=="remove",RUN+="systemctl stop media-automount@%k.service"

--- a/recipes-platform/media-automount/files/udev/99-media-automount.rules
+++ b/recipes-platform/media-automount/files/udev/99-media-automount.rules
@@ -1,0 +1,3 @@
+# Note: The RUN command needs absolute paths unless the executable resides under /var/udev.
+KERNEL=="sd[a-z][0-9]",SUBSYSTEM=="block",SUBSYSTEMS=="usb",ACTION=="add",RUN+="/bin/systemctl start media-automount@%k.service"
+KERNEL=="sd[a-z][0-9]",SUBSYSTEM=="block",SUBSYSTEMS=="usb",ACTION=="remove",RUN+="/bin/systemctl stop media-automount@%k.service"

--- a/recipes-platform/media-automount/media-automount_1.1.bb
+++ b/recipes-platform/media-automount/media-automount_1.1.bb
@@ -10,9 +10,9 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 SRC_URI += " \
-    file://sbin/mount_device.sh \
+    file://sbin/mount-media-device.sh \
     file://systemd/media-automount@.service \
-    file://udev/99-local.rules \
+    file://udev/99-media-automount.rules \
 "
 
 RDEPENDS_${PN} += "systemd udev bash"
@@ -31,7 +31,7 @@ do_install () {
     install -d ${D}${systemd_unitdir}/system
     install -d ${D}${sysconfdir}/udev/rules.d
 
-    install -m 0775 ${WORKDIR}/sbin/mount_device.sh ${D}${sbindir}/mount_device
+    install -m 0775 ${WORKDIR}/sbin/mount-media-device.sh ${D}${sbindir}/mount-media-device
     install -m 0644 ${WORKDIR}/systemd/media-automount@.service ${D}${systemd_unitdir}/system/
-    install -m 0644 ${WORKDIR}/udev/99-local.rules ${D}${sysconfdir}/udev/rules.d/
+    install -m 0644 ${WORKDIR}/udev/99-media-automount.rules ${D}${sysconfdir}/udev/rules.d/
 }


### PR DESCRIPTION
There was a minor issue in the mount script to clean up unused directories in `/media`.

The major problem were missing absolute paths in the udev rule triggering the mount script.